### PR TITLE
Review lesson 3

### DIFF
--- a/book/exercise_notebooks/exercise_notebook_week_4.ipynb
+++ b/book/exercise_notebooks/exercise_notebook_week_4.ipynb
@@ -95,7 +95,7 @@
    "source": [
     "<div class=\"alert alert-block alert-info\"><b>Exercise 3.1.3</b><br><br><div style=\"text-align: justify\">\n",
     "\n",
-    "In this exercise you need to write something opposite to a packager... an unpacker! Sometimes it is easier to work with the most convenient data type, that is best suited for a specific task. In this example, you have to write a function which accepts data stored in a dictionary and saves some data from it. More precisely, you have to select $x$ and $y$ coordinates saved in the <code>input_dict</code> dictionary, and return them as a tuple, with $x$ being the first entry.</div></div>"
+    "In this exercise you need to write something opposite to a packager... an unpacker! Sometimes it is easier to work with the most convenient data type, that is best suited for a specific task. In this example, you have to write a function which accepts data stored in a dictionary and saves some data from it. More precisely, you have to select the $x$ and $y$ coordinates saved in the <code>input_dict</code> dictionary, and return them as a tuple, with $x$ being the first entry.</div></div>"
    ]
   },
   {
@@ -145,7 +145,7 @@
     "\n",
     "In this exercise you will write your own Celsius to Fahrenheit converter! Your task is to write a function, which will accept the list of temperatures <code>temp_c</code>, in Celsius, and will output a list with the same temperatures, but in Fahrenheit. \n",
     "\n",
-    "Hint: create an empty list for the result, then append values to this list. See the \"personalized greeting\" example above.\n",
+    "Hint: create an empty list for the result, then append values to this list. See the \"personalized greeting\" example in Section 3.2.\n",
     "\n",
     "</div></div>"
    ]
@@ -234,7 +234,7 @@
     "Here you need to write a function that is able to sort any list consisting only of real numbers, in the descending order. For example, the list $[19, 5, 144, 6]$ becomes $[144, 19, 6, 5]$.\n",
     "\n",
     "\n",
-    "Hint: use a built-in <code>sort()</code> function to sort the list in ascending order, and then think of a clever way to change the order this list to descending order.\n",
+    "Hint: use a built-in <code>sorted()</code> function to sort the list in ascending order, and then think of a clever way to change the order this list to descending order.\n",
     "</div></div>"
    ]
   },
@@ -267,7 +267,7 @@
    },
    "source": [
     "<div class=\"alert alert-block alert-info\"><b>Exercise 3.2.4</b><br><br><div style=\"text-align: justify\">\n",
-    "Use a for loop and what you learned above about <code>range()</code> to print out every third element of the list <code>L</code>, starting from the second.\n",
+    "Use a for loop and what you learned about <code>range()</code> to print out every third element of the list <code>L</code>, starting from the second.\n",
     "</div></div>\n"
    ]
   },
@@ -308,7 +308,7 @@
     "    ...\n",
     "\n",
     "Angle = 180 # Degrees\n",
-    "print(f\"An angle of {Angle} Degrees is equal to {DegToRad(180):.3f} radians\")"
+    "print(f\"An angle of {Angle} Degrees is equal to {DegToRad(Angle):.3f} radians\")"
    ]
   },
   {
@@ -474,7 +474,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/book/notebook_1/PythonNotebook1_python_variables.ipynb
+++ b/book/notebook_1/PythonNotebook1_python_variables.ipynb
@@ -1065,7 +1065,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1079,7 +1079,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.10.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/book/notebook_3/PythonNotebook3_data_structures.ipynb
+++ b/book/notebook_3/PythonNotebook3_data_structures.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "In this Section you will tackle a data management problem! In the first module you have learned how to create variables, which is cool. But when you populate a lot of variables, or you want to store & access them within one entity, you need to have a data structure.\n",
     "\n",
-    "There are plenty of them, which differ their use cases and complexity. Today we will tackle some of the standard Python built-in data structures. The most popular of those are: <b><code>list</code></b>, <b><code>dict</code></b> and <b><code>tuple</code></b>."
+    "There are plenty of them, which differ their use cases and complexity. Today we will tackle some of the standard Python built-in data structures. The most popular of those are: <b><code>list</code></b>, <b><code>tuple</code></b> and <b><code>dict</code></b>."
    ]
   },
   {
@@ -61,15 +61,15 @@
     "# 1). Creating an empty list, option 1\n",
     "\n",
     "empty_list1 = []\n",
-    "print('Type of my_list1 object', type(empty_list1))\n",
-    "print('Contents of my_list1', empty_list1)\n",
+    "print(f'Type of my_list1 object: {type(empty_list1)}')\n",
+    "print(f'Contents of my_list1: {empty_list1}')\n",
     "print('--------------------')\n",
     "\n",
     "# 2). Creating an empty list, option 2 - using the class constructor\n",
     "\n",
     "empty_list2 = list()\n",
-    "print('Type of my_list2 object', type(empty_list2))\n",
-    "print('Contents of my_list2', empty_list2)\n",
+    "print(f'Type of my_list2 object: {type(empty_list2)}')\n",
+    "print(f'Contents of my_list2: {empty_list2}')\n",
     "print('--------------------')\n",
     "\n",
     "# 3). Creating a list from existing data - option 1\n",
@@ -79,8 +79,8 @@
     "my_var3 = 37.5\n",
     "\n",
     "my_list = [my_var1, my_var2, my_var3]\n",
-    "print('Type of my_list3 object', type(my_list))\n",
-    "print('Contents of my_list3', my_list)\n",
+    "print(f'Type of my_list3 object: {type(my_list)}')\n",
+    "print(f'Contents of my_list3: {my_list}')\n",
     "print('--------------------')\n",
     "\n",
     "# 4). Creating a list from existing data - option 2\n",
@@ -89,8 +89,8 @@
     "\n",
     "list_with_letters = list(cool_rock)\n",
     "\n",
-    "print('Type of my_list3 object', type(list_with_letters))\n",
-    "print('Contents of list_with_letters', list_with_letters)\n",
+    "print(f'Type of list_with_letters object: {type(list_with_letters)}')\n",
+    "print(f'Contents of list_with_letters: {list_with_letters}')\n",
     "print('--------------------')\n"
    ]
   },
@@ -108,9 +108,9 @@
     "As you can see, in all three cases we created a list, only the method how we did it was slightly different:\n",
     "\n",
     "- the first method uses the bracket notation,\n",
-    "- the second method uses class constructor approach. \n",
+    "- the second method uses the class constructor approach. \n",
     "\n",
-    "Both methods also apply to the other data structures.\n",
+    "Both methods also apply to the other data structures, as we will see later on.\n",
     "\n",
     "Now, we have a list — what can we do with it?\n",
     "\n",
@@ -141,9 +141,9 @@
     "print(len(my_list))\n",
     "\n",
     "# We have 3 elements, thus we can access 0th, 1st, and 2nd elements\n",
-    "print('First element of my list:', my_list[0])\n",
+    "print(f'First element of my list: {my_list[0]}')\n",
     "\n",
-    "print('Last element of my list:', my_list[2])\n",
+    "print(f'Last element of my list: {my_list[2]}')\n",
     "\n",
     "# After the element is accessed, it can be used as any variable,\n",
     "# the list only provides a convenient storage\n",
@@ -196,9 +196,11 @@
     "# adding a new element to the end of the list\n",
     "my_list.append(\"new addition to  my variable collection!\")\n",
     "print(my_list)\n",
+    "# Note the syntax here: mylist.append directly modifies mylist, and we thus don't need to reassign its output to mylist\n",
+    "# (so my_list = my_list.append(\"new addition\") will NOT work)\n",
     "\n",
     "# we can also store a list inside a list - list inception! Useful for matrices, images etc\n",
-    "my_list.append(['another list', False, 1 + 2j])\n",
+    "my_list.append(['another list', False, 1 + 2j])  # j is Python's notation for the imaginary number sqrt(-1)\n",
     "print(my_list)\n",
     "\n",
     "# Let's remove 37.5\n",
@@ -291,7 +293,7 @@
     "if 222 in lst1:\n",
     "    print('We found 222 inside lst1')\n",
     "else:\n",
-    "    print('Nope, nothing there....')"
+    "    print('Nope, it's not there....')"
    ]
   },
   {
@@ -309,7 +311,7 @@
     "\n",
     "If you understood how <code>list</code> works, then you already understand 95% of <b><code>tuple</code></b>. Tuples are just like lists, with some small differences.\n",
     "\n",
-    "1. In order to create a tuple you need to use <b><code>()</code></b> brackets, comma or a <b><code>tuple</code></b> class constructor.\n",
+    "1. In order to create a tuple you need to use <b><code>()</code></b> brackets, commas, or a <b><code>tuple</code></b> class constructor.\n",
     "2. You can change the content of your list, however <b>tuples are immutable</b> (just like strings).\n",
     "\n"
    ]
@@ -334,9 +336,9 @@
    "source": [
     "# Creating an empty tuple - a bit useless, since you cannot change it\n",
     "\n",
-    "tupl1 = tuple() # option 1 with class constructor\n",
-    "print('Type of tupl1', type(tupl1))\n",
-    "print('Content of tupl1', tupl1)\n",
+    "tupl1 = tuple() # option 1 with the class constructor\n",
+    "print(f'Type of tupl1: {type(tupl1)}')\n",
+    "print(f'Content of tupl1: {tupl1}')\n",
     "\n",
     "tupl2 = () # option 2 with ()\n",
     "print(type(tupl2), tupl2)"
@@ -361,15 +363,15 @@
     "my_var3 = False\n",
     "\n",
     "my_tuple = (my_var1, my_var2, my_var3, 'some additional stuff', 777)\n",
-    "print('my tuple', my_tuple)\n",
+    "print(f'my tuple: {my_tuple}')\n",
     "\n",
-    "# Creating a non-empty tuple using comma\n",
+    "# Creating a non-empty tuple using commas\n",
     "\n",
     "comma_tuple = 2, 'hi!', 228\n",
-    "print('A comma made tuple', comma_tuple)\n",
+    "print(f'A comma made tuple: {comma_tuple}')\n",
     "\n",
     "# now, let's try to access an element\n",
-    "print('4th element of my_tuple:', my_tuple[3])\n",
+    "print(f'4th element of my_tuple: {my_tuple[3]}')\n",
     "\n",
     "# but, can we change it?\n",
     "my_tuple[3] = 'will I change?'"
@@ -420,8 +422,8 @@
     "a = (my_name, my_age, is_student)\n",
     "b = [my_name, my_age, is_student]\n",
     "\n",
-    "print('size of a =', a.__sizeof__(), 'bytes') #.__sizeof__() determines the size of a variable in bytes\n",
-    "print('size of b =', b.__sizeof__(), 'bytes')"
+    "print(f'size of a = {a.__sizeof__()} bytes') #.__sizeof__() determines the size of a variable in bytes\n",
+    "print(f'size of b = {b.__sizeof__()} bytes')"
    ]
   },
   {
@@ -439,7 +441,7 @@
     "\n",
     "After seeing lists and tuples, you may think: \n",
     "\n",
-    "\"Wow, storing all my variables within another variable is cool and gnarly! But... sometimes it's boring & inconvenient to access my data by using it's position within a tuple/list. Is there a way that I can store my object within a data structure but access it via something meaningful, like a keyword...?\"\n",
+    "\"Wow, storing all my variables within another variable is cool and gnarly! But... sometimes it's boring & inconvenient to access my data by using it's position within a tuple/list, like when I have dozens of different variables in my tuple/list. Is there a way that I can store my object within a data structure but access it via something meaningful, like a keyword...?\"\n",
     "\n",
     "Don't worry if you had this exact same thought.. Python had it as well!\n",
     "\n",
@@ -467,13 +469,13 @@
     "# Now, it's time to use {}.\n",
     "\n",
     "empty_dict1 = {}\n",
-    "print('Type of empty_dict1', type(empty_dict1))\n",
-    "print('Content of it ->', empty_dict1)\n",
+    "print(f'Type of empty_dict1: {type(empty_dict1)}')\n",
+    "print(f'Content of it: {empty_dict1}')\n",
     "\n",
     "# Creating an empty dictionary - using class constructor\n",
     "empty_dict2 = dict()\n",
-    "print('Type of empty_dict2', type(empty_dict2))\n",
-    "print('Content of it ->', empty_dict2)"
+    "print(f'Type of empty_dict2: {type(empty_dict2)}')\n",
+    "print(f'Content of it: {empty_dict2}')"
    ]
   },
   {
@@ -498,7 +500,7 @@
     "    (2, 22): 'that is a strange key'\n",
     "}\n",
     "\n",
-    "print('Content of my_dict>>>', my_dict)"
+    "print(f'Content of my_dict: {my_dict}')"
    ]
   },
   {
@@ -624,8 +626,10 @@
    "outputs": [],
    "source": [
     "# Trying to access something we have and something we don't have\n",
-    "print('My favorite year is', my_dict['year'])\n",
-    "print('My favorite song is', my_dict['song'])"
+    "print(f'My favorite year is {my_dict[\"year\"]}')\n",
+    "print(f'My favorite song is {my_dict[\"song\"]}')  \n",
+    "# sidenote: when accessing keys in f-strings, you cannot repeat the same quote type \n",
+    "# (e.g., in f'xx' you cannot use ' but instead need \", since ' ends the f-string early and will throw an error)"
    ]
   },
   {
@@ -641,7 +645,8 @@
    "source": [
     "```{admonition} Attention\n",
     ":class: danger\n",
-    "It is best practice to use mainly <i><b>strings</b></i> as keys — the other options are weird and are almost never used.\n",
+    "It is best practice to use mainly <i><b>strings</b></i> as keys — the other options are error-prone (remember the floating-point\n",
+    "equality testing from Lesson 1), and are only extremely rarely used.\n",
     "+++\n",
     "```\n",
     "\n",
@@ -665,13 +670,14 @@
    },
    "outputs": [],
    "source": [
-    "print('my_dict right now', my_dict)\n",
+    "print(f'my_dict right now: {my_dict}')\n",
     "\n",
     "my_dict['new_element'] = 'magenta'\n",
     "my_dict['weight'] = 27.8\n",
+    "my_dict['extra_dict'] = {'dictionaries': ['can', 'contain', 'dictionaries', 'too']}  # dictionary inception, for very large datasets\n",
     "del my_dict['year']\n",
     "\n",
-    "print('my_dict after some operations', my_dict)"
+    "print(f'my_dict after some operations: {my_dict}')"
    ]
   },
   {
@@ -708,7 +714,7 @@
     "print(my_dict.keys())\n",
     "\n",
     "# check if my_dict has a name key\n",
-    "print(\"\\nmy_dict has a ['name'] key:\", 'name' in my_dict)"
+    "print(f\"\\nmy_dict has a ['name'] key: {'name' in my_dict}\")  #\\n is the newline character"
    ]
   },
   {
@@ -772,7 +778,7 @@
     "# like this => my_list[start:end], \n",
     "# it will select all elements with indices [start, end), \n",
     "# starting from start and ending at end-1 (excluding the end).\n",
-    "print('The first three elements of x:', x[0:3])\n",
+    "print(f'The first three elements of x: {x[0:3]}')\n",
     "\n",
     "# getting the same subset but using a different slice \"equation\"\n",
     "\n",
@@ -780,13 +786,13 @@
     "print(x[:3])\n",
     "\n",
     "# instead of counting elements from the beginning, we can count from end\n",
-    "print('The last element is', x[6], 'or', x[n - 1], 'or', x[-1])\n",
+    "print(f'The last element is {x[6]} or {x[n - 1]} or {x[-1]}')\n",
     "\n",
     "# thus, we can apply it in slicing our list\n",
     "print(x[0:-4])\n",
     "\n",
     "# we can also specify a third argument: the step size of our selection\n",
-    "print(x[0:3:1])"
+    "print(x[1:5:2])  # return elements with index 1 and 3"
    ]
   },
   {
@@ -827,8 +833,8 @@
     "# similar to omiting the 0 if you start at the beginning of the list\n",
     "# you can omit the last value if you want all values until the end\n",
     "print('Selecting all even numbers', numbers[::2])\n",
-    "# in the above case you start at 0 (omited), end at 10 (omited)\n",
-    "# with a step of 2 (not omited)\n",
+    "# in the above case you start at 0 (omitted), end at 10 (omitted)\n",
+    "# with a step of 2 (not omitted)\n",
     "\n",
     "print('All odd numbers', numbers[1::2])\n",
     "\n",
@@ -842,6 +848,75 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Copying lists\n",
+    "Copying lists sounds easy but is actually rather tricky. An example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_1 = [1, 2, 3]\n",
+    "list_2 = list_1\n",
+    "print(f'Original: {list_1}')\n",
+    "print(f'Copy: {list_2}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So far so good, both lists do in fact contain the same data, which is what we wanted. \n",
+    "\n",
+    "The tricky part shows when we start modifying one of the two lists:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_2[2] = 5\n",
+    "print(f'Original: {list_1}')\n",
+    "print(f'Copy: {list_2}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So what just happened? We modified the copy (list_2), and the original also changed? \n",
+    "\n",
+    "This happens because by copying the list in the way we did, Python did not copy the whole list, but rather the pointer to \n",
+    "where the list is stored in your computers memory (how exactly it does that is not important). This means that both the original \n",
+    "and the copy are stored at the same location in your computers memory, and modifying one therefore modifies the other.\n",
+    "\n",
+    "The way around this is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_1 = [1, 2, 3]\n",
+    "list_2 = list_1[:]  # this slice has the start and end omitted, so it is the full list\n",
+    "# but slicing forces Python to store it at a different spot in the computers memory\n",
+    "print(f'Original: {list_1}')\n",
+    "print(f'Copy: {list_2}')\n",
+    "list_2[2] = 5\n",
+    "print(f'Original: {list_1}')\n",
+    "print(f'Copy: {list_2}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "lDKimbtECAAz",
     "nbgrader": {
@@ -851,6 +926,12 @@
     }
    },
    "source": [
+    "```{admonition} Attention\n",
+    ":class: danger\n",
+    "To properly copy a list, you need to copy with slice notation. Otherwise unexpected stuff will happen.\n",
+    "+++\n",
+    "```\n",
+    "\n",
     "```{admonition} Additional study material:\n",
     ":class: tip\n",
     "\n",
@@ -859,6 +940,13 @@
     "+++\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -882,7 +970,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {

--- a/book/notebook_3/PythonNotebook3_debugging.ipynb
+++ b/book/notebook_3/PythonNotebook3_debugging.ipynb
@@ -61,6 +61,18 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{admonition} \n",
+    ":class: tip\n",
+    "Syntax checking has rapidly improved in recent years. In older versions of Python, some Syntax errors can be caused on the line <b>before</b> the line that is pointed out in the error (e.g. forgetting the `:` in an if-statement in the most recent versions of Python tells you that the `:` is missing, but in older versions will tell you it didn't expect the indent on the first line <b>after</b> the if-statement).\n",
+    "\n",
+    "+++\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "nbgrader": {
      "grade": false,
@@ -293,13 +305,6 @@
     "- know different types of errors\n",
     "- have a plan when debugging your code"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -318,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.10.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/book/notebook_3/PythonNotebook3_first_page.ipynb
+++ b/book/notebook_3/PythonNotebook3_first_page.ipynb
@@ -45,7 +45,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/book/notebook_3/PythonNotebook3_loops.ipynb
+++ b/book/notebook_3/PythonNotebook3_loops.ipynb
@@ -28,7 +28,7 @@
     }
    },
    "source": [
-    "Let's do another step to automatize things. Previous Sections introduced a lot of fundamental concepts, but they still don't unveil the true power of any programming language — loops!<br><br>If we want to perform the same procedure multiple times, then we would have to take the same code and copy-paste it. This approach would work, however it would require a lot of manual work and it does not look cool.<br><br>This problem is resolved with a <i>loop</i> construction. As the name suggest, this construction allows you to loop (or run) certain piece of code several times at one execution."
+    "Let's do another step to automatize things. Previous Sections introduced a lot of fundamental concepts, but they still don't unveil the true power of any programming language — loops!<br><br>If we want to perform the same procedure multiple times, then we would have to take the same code and copy-paste it. This approach would work, however it would require a lot of manual work and it does not look cool.<br><br>This problem is resolved with a <i>loop</i> construction. As the name suggest, this construction allows you to loop (or run) certain piece of code several times at one execution — without having to copy your code over and over again!"
    ]
   },
   {
@@ -73,7 +73,7 @@
     "\n",
     "print('Start of the loop')\n",
     "for list_item in my_list:\n",
-    "    print('In my list I can find:', list_item)\n",
+    "    print(f'In my list I can find: {list_item}')\n",
     "print('End of the loop')"
    ]
   },
@@ -129,12 +129,12 @@
     "# with a for loop\n",
     "\n",
     "x = [100, 'marble', False, 2, 2, [7, 7, 7], 'end']\n",
-    "print('Try #1, before:', x)\n",
+    "print(f'Try #1, before: {x}')\n",
     "\n",
     "for item in x:\n",
     "    item = [5,6,7]\n",
     "\n",
-    "print('Try #1, after', x)"
+    "print(f'Try #1, after: {x}')"
    ]
   },
   {
@@ -170,12 +170,12 @@
     "indices = range(length_of_x) # this will generate numbers from 0 till length_of_x, excluding the last one\n",
     "print(list(indices)) # print the numbers in the range (converted to a list)\n",
     "\n",
-    "print('Try #2, before', my_list)\n",
+    "print(f'Try #2, before: {my_list}')\n",
     "\n",
     "for id in indices:\n",
     "    my_list[id] = -1\n",
     "\n",
-    "print('Try #2, after', my_list)"
+    "print(f'Try #2, after: {my_list}')"
    ]
   },
   {
@@ -253,7 +253,7 @@
     "\n",
     "# you can also keep them within one list together\n",
     "expenses = [day1_expenses, day2_expenses, day3_expenses]\n",
-    "print('All my expenses', expenses)\n",
+    "print(f'All my expenses: {expenses}')\n",
     "\n",
     "# you can access also each expense separately!\n",
     "# day3 is third array and 2nd expense is second element \n",
@@ -399,9 +399,9 @@
     "sum = 0\n",
     "\n",
     "while sum < 5:\n",
-    "    print('sum in the beginning of the cycle:', sum)\n",
+    "    print(f'sum in the beginning of the cycle: {sum}')\n",
     "    sum += 1\n",
-    "    print('sum in the end of the cycle:', sum)\n",
+    "    print(f'sum in the end of the cycle: {sum}')\n",
     "    print() # a blank line"
    ]
   },
@@ -681,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.10.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
- Remove /replace references to 'above' in the exercises
- Replace 'sort' with 'sorted' ('sort' doesn't exist) in exercise 3.2.3
- Proper variable propagation in exercise 3.2.5 (so they can actually change it if the students want to)
- Changed all print commands to f-strings (since we ask it from the students, we should do it too)
- Fixed the order and grammar of a few strings
- Added small clarification on that x.append directly modifies x so we don't need to re-assign it to x
- Added small clarification what 1+2j means
- Added small explanation in the dictionary section for the students that didn't realize why they should be thinking that lists are impractical sometimes
- Added a note on using strings inside {} in f-strings
- Better explanation on why to only use strings as keys (original was 'it's weird')
- Added an example of a dictionary inside a dictionary
- Explained '\n'
- Better example of slicing with a step ([0:3:1] doesn't really show what it does, [1:5:2] does)
- Added a short section on copying lists to section 3.1 (a=b doesn't work, a=b[:] does) (since this is unexpected behaviour)
- Added a tip to the syntax error section on older versions, where the line number is not always shown correctly (saw this trip up many students during exams). 3.10+ syntax checking seems to have patched it (at least I cannot find a working example any more), but there's still a lot of pre-3.10 code around